### PR TITLE
Better entity filter

### DIFF
--- a/oshdb-contributions/src/main/java/AdvTagTranslator.java
+++ b/oshdb-contributions/src/main/java/AdvTagTranslator.java
@@ -1,0 +1,125 @@
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBRole;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBTag;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBTagKey;
+import org.heigit.bigspatialdata.oshdb.util.TableNames;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBKeytablesNotFoundException;
+import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMRole;
+import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTag;
+import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTagKey;
+import org.heigit.bigspatialdata.oshdb.util.tagtranslator.TagTranslator;
+
+public class AdvTagTranslator implements AutoCloseable {
+  private static final Comparator<OSHDBTagKey> keyOrder =
+      (a, b) -> Integer.compare(a.toInt(), b.toInt());
+
+  private final Connection conn;
+  private final TagTranslator tagTranslator;
+
+  private final PreparedStatement keyCaseInsensitive;
+
+  public AdvTagTranslator(Connection conn) throws SQLException, OSHDBKeytablesNotFoundException {
+    this.conn = conn;
+    this.tagTranslator = new TagTranslator(conn);
+    this.keyCaseInsensitive = conn.prepareStatement(
+        "select ID from " + TableNames.E_KEY.toString() + " where KEY.TXT ilike ? ;");
+  }
+
+  @Override
+  public void close() throws Exception {
+    conn.close();
+  }
+
+  public Map<String, String> getTagsAsKeyValueMap(Iterable<OSHDBTag> tags) {
+    Map<String, String> map = new HashMap<>();
+    for (OSHDBTag tag : tags) {
+      OSMTag translated = getOSMTagOf(tag);
+      map.put(translated.getKey(), translated.getValue());
+
+    }
+    return map;
+  }
+
+  public OSHDBTagKey getOSHDBTagKeyOf(String key) {
+    return tagTranslator.getOSHDBTagKeyOf(key);
+  }
+
+  public Set<OSHDBTagKey> getOSHDBTagKeyOf(String key, boolean caseSensitive) throws SQLException {
+    if (caseSensitive) {
+      return Collections.singleton(getOSHDBTagKeyOf(key));
+    }
+
+    SortedSet<OSHDBTagKey> set = new TreeSet<>(keyOrder);
+
+    keyCaseInsensitive.setString(1, key.toString());
+    try (ResultSet keys = keyCaseInsensitive.executeQuery()) {
+      while (keys.next()) {
+        set.add(new OSHDBTagKey(keys.getInt("ID")));
+      }
+    }
+    return set;
+  }
+
+  public OSHDBTagKey getOSHDBTagKeyOf(OSMTagKey key) {
+    return tagTranslator.getOSHDBTagKeyOf(key);
+  }
+
+  public OSMTagKey getOSMTagKeyOf(int key) {
+    return tagTranslator.getOSMTagKeyOf(key);
+  }
+
+  public OSMTagKey getOSMTagKeyOf(OSHDBTagKey key) {
+    return tagTranslator.getOSMTagKeyOf(key);
+  }
+
+  public OSHDBTag getOSHDBTagOf(String key, String value) {
+    return tagTranslator.getOSHDBTagOf(key, value);
+  }
+
+  public OSHDBTag getOSHDBTagOf(OSMTag tag) {
+    return tagTranslator.getOSHDBTagOf(tag);
+  }
+
+  public OSMTag getOSMTagOf(int key, int value) {
+    return tagTranslator.getOSMTagOf(key, value);
+  }
+
+  public OSMTag getOSMTagOf(OSHDBTag tag) {
+    return tagTranslator.getOSMTagOf(tag);
+  }
+
+  public OSHDBRole getOSHDBRoleOf(String role) {
+    return tagTranslator.getOSHDBRoleOf(role);
+  }
+
+  public OSHDBRole getOSHDBRoleOf(OSMRole role) {
+    return tagTranslator.getOSHDBRoleOf(role);
+  }
+
+  public OSMRole getOSMRoleOf(int role) {
+    return tagTranslator.getOSMRoleOf(role);
+  }
+
+  public OSMRole getOSMRoleOf(OSHDBRole role) {
+    return tagTranslator.getOSMRoleOf(role);
+  }
+
+  public Connection getConnection() {
+    return tagTranslator.getConnection();
+  }
+
+
+
+}


### PR DESCRIPTION
pushing the filter into MapReduce.osmEntityFilter helps to discard as early as possible unwanted entities. 
This will reduce the overhead of creating all the major-/minor version and geometries.
To filter in the ContributionView.map method is actually to late because at this point all the major-/minor version are already computed.
This should speed up the analysis and hopefully also avoid the out-of-memory exceptions.

For getting case insensitive tag keys like "admin_level" and mapping OSHDBTags to a key-value map, I extended the regular TagTranslator to AvdTagTranslator, I will discuss this in our group if we would like to add those extension to the regular one as well.

I also replace the logic for extracting the tag changes from one version to the next, with guavas Maps.difference.
https://github.com/google/guava/wiki/CollectionUtilitiesExplained#maps
But please take a look at this if this is still the logic you wanted and needed. I didn't test this code against a database.


example for different "admin_level" spellings. :-|
92	"admin_level"
25718	"admin_Level"
11043	"admin level"
13659	"admin-level"
51088	"admin:level"
48669	"Admin_level"
53007	"ADMIN_LEVEL"
58844	"Admin Level"
59375	"admIn_level"
79504	"admin)level"
116375	"Admin-level"
94745	"admin+level"
94746	"admin-Level"
136784	"admin°level"

